### PR TITLE
[Propuesta] API

### DIFF
--- a/LiveCoding/mvc/.htaccess
+++ b/LiveCoding/mvc/.htaccess
@@ -3,5 +3,6 @@
   RewriteCond %{REQUEST_FILENAME} -f [OR]
   RewriteCond %{REQUEST_FILENAME} -l
   RewriteRule ^[css|img|js].*$ - [L]
+  RewriteRule ^api/(.*)$ api/route.php?resource=$1 [QSA,L]
   RewriteRule ^(.*)$ route.php?action=$1 [QSA,L]
 </IfModule>

--- a/LiveCoding/mvc/api/Api.php
+++ b/LiveCoding/mvc/api/Api.php
@@ -1,0 +1,27 @@
+<?php
+class Api
+{
+  protected $model;
+
+  public function __construct()
+  {
+    header("Content-Type: application/json");
+  }
+
+  public function response($data, $status = 200)
+  {
+    header("HTTP/1.1 " . $status . " " . $this->_requestStatus($status));
+    return json_encode($data);
+  }
+
+  private function _requestStatus($code){
+    $status = array(
+      200 => "OK",
+      404 => "Not found",
+      500 => "Internal Server Error"
+    );
+    return ($status[$code])? $status[$code] : $status[500];
+  }
+}
+
+ ?>

--- a/LiveCoding/mvc/api/TareasApi.php
+++ b/LiveCoding/mvc/api/TareasApi.php
@@ -1,0 +1,38 @@
+<?php
+
+include_once '../model/Model.php';
+include_once '../model/TareasModel.php';
+class TareasAPI
+{
+  private $model;
+
+  public function __construct(Type $foo = null)
+  {
+    $this->model = new TareasModel();
+  }
+
+  function get($params=''){
+    if(empty($params)){
+      header("Content-Type: application/json");
+      header("HTTP/1.1 200 OK");
+      return json_encode($this->model->getTareas());
+    }
+    else{
+      $tarea = $this->model->getTarea($params[0]);
+      if(!empty($tarea)){
+        header("Content-Type: application/json");
+        header("HTTP/1.1 200 OK");
+        return json_encode($tarea);
+      }
+      else{
+        header("Content-Type: application/json");
+        header("HTTP/1.1 404 Not Found");
+        $error['error'] = "La tarea no existe";
+        return json_encode($error);
+      }
+    }
+  }
+
+}
+
+ ?>

--- a/LiveCoding/mvc/api/TareasApi.php
+++ b/LiveCoding/mvc/api/TareasApi.php
@@ -1,34 +1,25 @@
 <?php
-
-include_once '../model/Model.php';
 include_once '../model/TareasModel.php';
-class TareasAPI
+class TareasAPI extends Api
 {
-  private $model;
-
-  public function __construct(Type $foo = null)
+  public function __construct()
   {
     $this->model = new TareasModel();
   }
 
   function get($params=''){
     if(empty($params)){
-      header("Content-Type: application/json");
-      header("HTTP/1.1 200 OK");
-      return json_encode($this->model->getTareas());
+      $tareas = $this->model->getTareas();
+      return $this->response($tareas);
     }
     else{
       $tarea = $this->model->getTarea($params[0]);
       if(!empty($tarea)){
-        header("Content-Type: application/json");
-        header("HTTP/1.1 200 OK");
-        return json_encode($tarea);
+        return $this->response($tarea);
       }
       else{
-        header("Content-Type: application/json");
-        header("HTTP/1.1 404 Not Found");
         $error['error'] = "La tarea no existe";
-        return json_encode($error);
+        return $this->response($error, 404);
       }
     }
   }

--- a/LiveCoding/mvc/api/config/ConfigApi.php
+++ b/LiveCoding/mvc/api/config/ConfigApi.php
@@ -1,0 +1,14 @@
+<?php
+
+class ConfigApi
+{
+    public static $RESOURCE = 'resource';
+    public static $PARAMS = 'params';
+    public static $METHOD = 'method';
+    public static $RESOURCES = [
+      'tarea#GET' => 'TareasApi#get'
+    ];
+
+}
+
+ ?>

--- a/LiveCoding/mvc/api/route.php
+++ b/LiveCoding/mvc/api/route.php
@@ -2,7 +2,9 @@
 define('RESOURCE', 0);
 define('PARAMS', 1);
 
+include_once '../model/Model.php';
 include_once 'config/ConfigApi.php';
+include_once 'Api.php';
 include_once 'TareasApi.php';
 
 function parseURL($url)

--- a/LiveCoding/mvc/api/route.php
+++ b/LiveCoding/mvc/api/route.php
@@ -1,0 +1,33 @@
+<?php
+define('RESOURCE', 0);
+define('PARAMS', 1);
+
+include_once 'config/ConfigApi.php';
+include_once 'TareasApi.php';
+
+function parseURL($url)
+{
+  $urlExploded = explode('/', $url);
+  $arrayReturn[ConfigApi::$RESOURCE] = $urlExploded[RESOURCE] . '#' . $_SERVER['REQUEST_METHOD'];
+  $arrayReturn[ConfigApi::$PARAMS] = isset($urlExploded[PARAMS]) ? array_slice($urlExploded,1) : null;
+  return $arrayReturn;
+}
+
+if(isset($_GET['resource'])){
+    $urlData = parseURL($_GET['resource']);
+    $resource = $urlData[ConfigApi::$RESOURCE];
+    if(array_key_exists($resource,ConfigApi::$RESOURCES)){
+        $params = $urlData[ConfigApi::$PARAMS];
+        $action = explode('#',ConfigApi::$RESOURCES[$resource]);
+        $controller =  new $action[0]();
+        $method = $action[1];
+        if(!empty($params)){
+            echo $controller->$method($params);
+        }
+        else{
+            echo $controller->$method();
+        }
+    }
+}
+
+ ?>

--- a/LiveCoding/mvc/model/TareasModel.php
+++ b/LiveCoding/mvc/model/TareasModel.php
@@ -7,6 +7,12 @@ class TareasModel extends Model
     return $sentencia->fetchAll(PDO::FETCH_ASSOC);
   }
 
+  function getTarea($id_tarea){
+    $sentencia = $this->db->prepare( "select * from tarea where id_tarea=?");
+    $sentencia->execute([$id_tarea]);
+    return $sentencia->fetchAll(PDO::FETCH_ASSOC);
+  }
+
   function guardarTarea($titulo, $descripcion, $completada){
     $sentencia = $this->db->prepare('INSERT INTO tarea(titulo,descripcion,completado) VALUES(?,?,?)');
     $sentencia->execute([$titulo,$descripcion,$completada]);


### PR DESCRIPTION
La idea es para la clase de 07 - API REST.
En lugar de para la API manejar toda una idea nueva de Router, la propuesta es usar uno parecido al que tenemos.

# Primera Parte de la Clase
* Editamos el htaccess, para que redirija a `route.php` pero de la API.
* Cambiamos el nombre del parámetro para matchear un poco mas REST, en lugar de action usamos resouce.
* Dentro de la carpeta api creamos un config folder, donde ponemos `ConfigApi.php`. En este archivo vamos a tener toda la config para la API.

## Opcion 1
* La idea es tener en lugar de actions, resources, mapeados a métodos del Controller de la API.
```
public static $RESOURCES = [
      'tarea#GET' => 'TareasApi#get'
 ];
```
* Vamos a usar la idea de que la Key del arreglo es `resource#method`.
* Modificamos el Router para que cumpla con esto.

El problema acá es tener una ruta diferente para el get con parámetros, que con sin parámetros.
En este caso opte por manejar los parámetros dentro del método get del controller.

## Opcion 2
Otra opción es crear un `$RESOURCES` con multiples niveles 
```
public static $RESOURCES = [
      'tarea#GET' => [ 'parameters' => 'TareasApi#getTareas', 'no-parameters' => 'TareasApi#getTarea']
 ];
```
Me parece un poco mas "Dificil".

Hasta aca la primera parte (todo en el primer commit de este PR)

# Segunda Parte de la Clase
* Implementar el get de una sola tarea
* Aca puede haber algun error, por ejemplo que la tarea no exista.
* Escribir todo el codigo, hacelo andar
* Ver como se duplica el codigo
* Abstraer Api.
